### PR TITLE
bedtools2: add sample data

### DIFF
--- a/tools/bedtools2/compile.sh
+++ b/tools/bedtools2/compile.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
 cd src/
+
+# Remove large files (we'll pre-load the rest of the files as examples)
+rm -rf ./test/intersect/sortAndNaming/bigTests
+
+# Generate obj/*.o files
+make clean
 emmake make
 
 # Generate .wasm/.js files
 emcc obj/*.o \
-    -o ../build/bedtools2.html \
+    -o ../build/bedtools2.js \
+    -O2 \
+    --preload-file test@/bedtools2/test \
     $EM_FLAGS \
     -s ERROR_ON_UNDEFINED_SYMBOLS=0


### PR DESCRIPTION
This PR:

- Updates bedtools2 to v2.29.2
- Preload sample data to `bedtools2` (~1.7MB as bedtools2.data); skip over the `intersect/sortAndNaming/bigTests` sample data as it's > 40MB.