### PR TITLE
Issue 28: samtools sort not working

### DIFF
--- a/cloudflare/playground/src/config.js
+++ b/cloudflare/playground/src/config.js
@@ -1,5 +1,5 @@
 // CDN
-const TESTING = false;
+const TESTING = window.location.host == "localhost" || window.location.host.includes("-stg");
 export const BIOWASM_URL = `https://cdn${TESTING ? "-stg" : ""}.biowasm.com`;
 
 // Constants

--- a/tools/samtools/patch
+++ b/tools/samtools/patch
@@ -20,6 +20,27 @@ index 160314a..8c64e7a 100644
  	$(CC) $(ALL_LDFLAGS) -o $@ $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB_LIB) $(CURSES_LIB) -lm $(ALL_LIBS) -lpthread
  
  # For building samtools and its test suite only: NOT to be installed.
+diff --git a/bam_sort.c b/bam_sort.c
+index 0bf346c..22aff33 100644
+--- a/bam_sort.c
++++ b/bam_sort.c
+@@ -2027,15 +2027,7 @@ static int sort_blocks(int n_files, size_t k, bam1_tag *buf, const char *prefix,
+             w[i].no_save = 0;
+         }
+         pos += w[i].buf_len; rest -= w[i].buf_len;
+-        pthread_create(&tid[i], &attr, worker, &w[i]);
+-    }
+-    for (i = 0; i < n_threads; ++i) {
+-        pthread_join(tid[i], 0);
+-        if (w[i].error != 0) {
+-            errno = w[i].error;
+-            print_error_errno("sort", "failed to create temporary file \"%s.%.4d.bam\"", prefix, w[i].index);
+-            n_failed++;
+-        }
++        worker(&w[0]);
+     }
+     free(tid); free(w);
+     if (n_failed) return -1;
 diff --git a/bamtk.c b/bamtk.c
 index a6959f9..5a44af6 100644
 --- a/bamtk.c


### PR DESCRIPTION
This PR fixes #28, where `samtools sort` does not sort the file because it relies on pthreads, which are currently turned off.

Thanks to @pinbo for identifying the issue and finding a fix!

---

As a test, run `make htslib && make samtools` and go to the following URLs:
* http://localhost/tools/samtools/build/samtools.html
* https://cdn.biowasm.com/samtools/1.10/samtools.html

In each website, run the following JS code in the developer console:

```javascript
FS.writeFile("/test.sam", `@HD\tVN:1.6\tSO:coordinate\n@SQ\tSN:CHROMOSOME_I\tLN:1009800\tM5:8ede36131e0dbf3417807e48f77f3ebd\n@PG\tID:bowtie2\tPN:bowtie2\tVN:2.0.0-beta5\nSRR065390.15493040\t0\tCHROMOSOME_I\t999912\t42\t100M\t*\t0\t0\tACTTCAAGCAGAGGATTTTTCGATGATTGCCAAAAATTTTGGAACTTTTATAGGCTTAAGCTTATGGTTATGTTTAGGCGTAGGCTTAGGCTTAGGCGTA\tCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCDBCCBDBCCBDDA@>DC?5@?@@??:><<>8>39<37\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:100\tYT:Z:UU\nSRR065390.6144221\t0\tCHROMOSOME_I\t999914\t42\t100M\t*\t0\t0\tTTCAAGCAGAGGATTTTTCGATGATTGCCAAAAATTTTGGAACTTTTATAGGCTTAAGCTTATGGTTATGTTTAGGCGTAGGCTTAGGCTTAGGCGTAGG\tCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCDCCCCDCCCCBDCDDBBDDBDBDD@BBB@DBABDB\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:100\tYT:Z:UU\nSRR065390.17240207\t16\tCHROMOSOME_I\t999901\t42\t100M\t*\t0\t0\tATGTTTACAGGACTTCAAGCAGAGGATTTTTCGATGATTGCCAAAAATTTTGGAACTTTTATAGGCTTAAGCTTATGGTTATGTTTAGGCGTAGGCTTAG\tCACAC?CBBAA@?@?BADDBBDBBAB>DDDBBDDABBBCCADDDDDCBCBCCCDBDDCDCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:100\tYT:Z:UU`)
Module.callMain("sort -O SAM /test.sam".split(" "));
```

The localhost one correctly sorts the SAM file.
