### PR TITLE
Cleanup compilation logs and reduce file size

### DIFF
--- a/tools/bedtools2/patches/v2.29.2
+++ b/tools/bedtools2/patches/v2.29.2
@@ -1,7 +1,16 @@
 diff --git a/Makefile b/Makefile
-index 6bc3cb98..23c36145 100644
+index 6bc3cb98..33d31f58 100644
 --- a/Makefile
 +++ b/Makefile
+@@ -28,7 +28,7 @@ BT_CPPFLAGS = -DDEBUG -D_DEBUG -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API $(INCLUD
+ BT_CXXFLAGS = -Wconversion -Wall -Wextra -g -O0
+ else
+ BT_CPPFLAGS = -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API $(INCLUDES)
+-BT_CXXFLAGS = -g -Wall -O2
++BT_CXXFLAGS = -w -O2
+ endif
+ 
+ # If the user has specified to do so, tell the compile to use rand() (instead of mt19937).
 @@ -173,7 +173,7 @@ $(BUILT_OBJECTS): | $(OBJ_DIR)
  
  $(BIN_DIR)/bedtools: autoversion $(BUILT_OBJECTS) $(HTSDIR)/libhts.a | $(BIN_DIR)

--- a/tools/bhtsne/compile.sh
+++ b/tools/bhtsne/compile.sh
@@ -8,7 +8,7 @@ test -f data/pollen2014.snd || gunzip data/pollen2014.snd.gz
 cd src/
 emmake make \
     CC=emcc CXX=em++ \
-    CFLAGS+="-s USE_ZLIB=1" \
+    CFLAGS="-O2 -s USE_ZLIB=1 -w" \
     LIBS="-s USE_ZLIB=1 -lm"
 
 # Generate .wasm/.js files

--- a/tools/fastp/patches/0.20.1
+++ b/tools/fastp/patches/0.20.1
@@ -1,3 +1,16 @@
+diff --git a/Makefile b/Makefile
+index afc7e9e..343b587 100644
+--- a/Makefile
++++ b/Makefile
+@@ -15,7 +15,7 @@ TARGET := fastp
+ BIN_TARGET := ${TARGET}
+ 
+ CXX ?= g++
+-CXXFLAGS := -std=c++11 -g -O3 -I${DIR_INC} $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) ${CXXFLAGS}
++CXXFLAGS := -std=c++11 -O3 -I${DIR_INC} $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) ${CXXFLAGS}
+ LIBS := -lz -lpthread
+ LD_FLAGS := $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir)) $(LIBS) $(LD_FLAGS)
+ 
 diff --git a/src/htmlreporter.cpp b/src/htmlreporter.cpp
 index c3ac291..e81d0d7 100644
 --- a/src/htmlreporter.cpp

--- a/tools/samtools/patches/1.10
+++ b/tools/samtools/patches/1.10
@@ -54,3 +54,16 @@ index a6959f9..5a44af6 100644
      if (strcmp(argv[1], "view") == 0)           ret = main_samview(argc-1, argv+1);
      else if (strcmp(argv[1], "import") == 0)    ret = main_import(argc-1, argv+1);
      else if (strcmp(argv[1], "mpileup") == 0)   ret = bam_mpileup(argc-1, argv+1);
+diff --git a/version.sh b/version.sh
+index 5ccd9bb..bb7032a 100755
+--- a/version.sh
++++ b/version.sh
+@@ -30,7 +30,7 @@ VERSION=1.10
+ if [ -e .git ]
+ then
+     # If we ever get to 10.x this will need to be more liberal
+-    VERSION=`git describe --match '[0-9].[0-9]*' --dirty --always`
++    VERSION=`git describe --match '[0-9].[0-9]*' --always`
+ fi
+ 
+ echo $VERSION

--- a/tools/wgsim/compile.sh
+++ b/tools/wgsim/compile.sh
@@ -4,4 +4,4 @@ cd src/
 emcc wgsim.c \
     -o ../build/wgsim.html \
     $EM_FLAGS \
-    -lm -O2 -Wall
+    -lm -O2 -w


### PR DESCRIPTION
This PR does some more cleanup:
* Remove use of `-g` (debug flag) to reduce `.wasm` binary file sizes
* Use `-w` to not pollute the GitHub Actions logs with warnings
* Samtools: don't append `-dirty` to the version number
