### PR TITLE
Issue 40: CDN stats cron failing

### DIFF
--- a/cloudflare/cdn/entrypoint/index.js
+++ b/cloudflare/cdn/entrypoint/index.js
@@ -43,7 +43,7 @@ addEventListener("fetch", event => {
       // Increment count
       let counter = parseInt(await LOGS.get(key) || 0) + 1;
       // Save count in the metadata so we can retrieve it in bulk when doing .list() for CDN stats
-      await LOGS.put(key, null, { metadata: counter });
+      await LOGS.put(key, "", { metadata: counter });
     }
     event.waitUntil(logEvent(url.pathname));
   }

--- a/cloudflare/cdn/entrypoint/index.js
+++ b/cloudflare/cdn/entrypoint/index.js
@@ -42,7 +42,8 @@ addEventListener("fetch", event => {
       let key = `${new Date().toISOString().split("T").shift()}|${path}`;
       // Increment count
       let counter = parseInt(await LOGS.get(key) || 0) + 1;
-      await LOGS.put(key, counter);
+      // Save count in the metadata so we can retrieve it in bulk when doing .list() for CDN stats
+      await LOGS.put(key, null, { metadata: counter });
     }
     event.waitUntil(logEvent(url.pathname));
   }

--- a/cloudflare/stats/migration-2021-04-09.js
+++ b/cloudflare/stats/migration-2021-04-09.js
@@ -1,0 +1,39 @@
+// Script to migrate from storing the download counts in the "value" field and into
+// the "metadata" field instead. This is because "metadata" is included in the response
+// to a .list() command, whereas "value" requires a separate .get() request for each! i.e.
+// this is much much faster for calculating stats
+// 
+// Before:
+//   { key: "path", value: 123 }
+// After:
+//   { key: "path", value: "", metadata: 123 }
+
+addEventListener("fetch", event => {
+  event.respondWith(handleRequest(event.request));
+});
+
+async function handleRequest(request)
+{
+    let response = { cursor: null };
+    do {
+        let response = { cursor: null };
+            response = await LOGS_STG.list({
+            cursor: response.cursor
+        });
+
+        let i = 0;
+        for(let obj of response.keys) {
+            if(i++ % 50 == 0)
+                console.log(`${i} / ${response.keys.length}...`)
+
+            // Need to put one metadata at a time. Currently, "wrangler kv:bulk" doesn't
+            // support a PUT operation that includes metadata
+            if(obj.metadata != null)
+                continue;
+            const count = await LOGS_STG.get(obj.name);
+            await LOGS_STG.put(obj.name, "", { metadata: parseInt(count) })
+        }
+    } while(response.cursor != null);
+
+    return new Response('done', {status: 200});
+}

--- a/cloudflare/stats/migration-2021-04-09.js
+++ b/cloudflare/stats/migration-2021-04-09.js
@@ -16,8 +16,7 @@ async function handleRequest(request)
 {
     let response = { cursor: null };
     do {
-        let response = { cursor: null };
-            response = await LOGS_STG.list({
+        response = await LOGS_STG.list({
             cursor: response.cursor
         });
 


### PR DESCRIPTION
This PR:
* Updates the CDN script to store download counts in the metadata instead of the key-value pair
* Updates the stats cron so it uses the metadata counts. The cron runs much faster as a result since metadata info is obtained with a `.list()` command (previously, had to get the value of each key one at a time!)
