### PR TITLE
Cache static CDN files for a week for faster loading times

### DIFF
--- a/cloudflare/cdn/entrypoint/index.js
+++ b/cloudflare/cdn/entrypoint/index.js
@@ -61,6 +61,13 @@ async function handleEvent(event) {
    * by configuring the function `mapRequestToAsset`
    */
   options.mapRequestToAsset = handlePrefix(/^\//);
+  options.cacheControl = {
+    browserTTL: 604800  // 1 week
+    // Defaults:
+    //   browserTTL: null, // do not set cache control ttl on responses
+    //   edgeTTL: 2 * 60 * 60 * 24, // 2 days
+    //   bypassCache: false, // do not bypass Cloudflare's cache
+  };
 
   try {
     if (DEBUG) {


### PR DESCRIPTION
This PR asks browsers to cache static files served by `cdn.biowasm.com` (i.e. .js, .wasm files) to improve performance after the first load. This sets the [browser TTL cache](https://support.cloudflare.com/hc/en-us/articles/200168276-Understanding-Browser-Cache-TTL#h_77vhcFRgOlmdaJ0Xy3U1C) to 1 week.