### PR TITLE
Upgrade Emscripten to 2.0.25

### DIFF
--- a/.github/workflows/deploy-cdn-stg.yml
+++ b/.github/workflows/deploy-cdn-stg.yml
@@ -32,6 +32,7 @@ jobs:
       # Deploy to Cloudflare Workers
       # ------------------------------------------------------------------------
       - name: Deploy cdn-stg.biowasm.com
+        if: ${{ !env.ACT }}
         uses: cloudflare/wrangler-action@1.3.0
         env:
           USER: root
@@ -43,6 +44,7 @@ jobs:
           preCommands: cd cloudflare/cdn
 
       - name: Deploy stats-stg.biowasm.com
+        if: ${{ !env.ACT }}
         uses: cloudflare/wrangler-action@1.3.0
         env:
           USER: root
@@ -54,6 +56,7 @@ jobs:
           preCommands: cd cloudflare/stats
 
       - name: Deploy play-stg.biowasm.com
+        if: ${{ !env.ACT }}
         uses: cloudflare/wrangler-action@1.3.0
         env:
           USER: root
@@ -65,6 +68,7 @@ jobs:
           preCommands: cd cloudflare/playground && npm install && npm run build
 
       - name: Deploy stg.biowasm.com home page
+        if: ${{ !env.ACT }}
         uses: cloudflare/wrangler-action@1.3.0
         env:
           USER: root

--- a/.github/workflows/deploy-cdn-stg.yml
+++ b/.github/workflows/deploy-cdn-stg.yml
@@ -16,10 +16,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download Emscripten
-        uses: mymindstorm/setup-emsdk@v7
+        uses: mymindstorm/setup-emsdk@v10
         with:
-          version: 2.0.0
-
+          version: 2.0.25
       - name: Test Emscripten
         run: emcc -v
 

--- a/config/shared.default.sh
+++ b/config/shared.default.sh
@@ -4,7 +4,7 @@ EM_FLAGS_BASE=$(cat <<EOF
     -s USE_ZLIB=1
     -s INVOKE_RUN=0
     -s FORCE_FILESYSTEM=1
-    -s EXTRA_EXPORTED_RUNTIME_METHODS=["callMain"]
+    -s EXPORTED_RUNTIME_METHODS=["callMain"]
     -lworkerfs.js
 EOF
 )

--- a/tools/bedtools2/patches/v2.29.2
+++ b/tools/bedtools2/patches/v2.29.2
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 6bc3cb98..33d31f58 100644
+index 6bc3cb98..ecaab01e 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -28,7 +28,7 @@ BT_CPPFLAGS = -DDEBUG -D_DEBUG -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API $(INCLUD
@@ -11,6 +11,15 @@ index 6bc3cb98..33d31f58 100644
  endif
  
  # If the user has specified to do so, tell the compile to use rand() (instead of mt19937).
+@@ -130,7 +130,7 @@ ALL_LDFLAGS  = $(BT_LDFLAGS) $(LDFLAGS)
+ ALL_LIBS     = $(BT_LIBS) $(LIBS)
+ 
+ 
+-all: print_banner $(BIN_DIR)/bedtools $(BIN_DIR)/intersectBed
++all: print_banner $(BIN_DIR)/bedtools
+ 
+ static: print_banner $(BIN_DIR)/bedtools.static
+ 
 @@ -173,7 +173,7 @@ $(BUILT_OBJECTS): | $(OBJ_DIR)
  
  $(BIN_DIR)/bedtools: autoversion $(BUILT_OBJECTS) $(HTSDIR)/libhts.a | $(BIN_DIR)

--- a/tools/bhtsne/compile.sh
+++ b/tools/bhtsne/compile.sh
@@ -16,7 +16,7 @@ emcc -O2 -o ../build/t-sne.html t-sne-prgm.o \
     $EM_FLAGS \
     -s ASYNCIFY=1 \
     -s 'ASYNCIFY_IMPORTS=["send_names","send_results"]' \
-    -s EXTRA_EXPORTED_RUNTIME_METHODS=["callMain","getValue","UTF8ToString"] \
+    -s EXPORTED_RUNTIME_METHODS=["callMain","getValue","UTF8ToString"] \
     --preload-file ../data/brain8.snd@/bhtsne/brain8.snd \
     --preload-file ../data/pollen2014.snd@/bhtsne/pollen2014.snd
 

--- a/tools/bhtsne/compile.sh
+++ b/tools/bhtsne/compile.sh
@@ -7,6 +7,7 @@ test -f data/pollen2014.snd || gunzip data/pollen2014.snd.gz
 # Compile
 FLAGS=$(cat <<EOF
     $EM_FLAGS \
+    -O3 \
     -s ASYNCIFY=1 \
     -s 'ASYNCIFY_IMPORTS=["send_names","send_results"]' \
     -s EXPORTED_RUNTIME_METHODS=["callMain","getValue","UTF8ToString"] \

--- a/tools/bhtsne/compile.sh
+++ b/tools/bhtsne/compile.sh
@@ -5,20 +5,21 @@ test -f data/brain8.snd || gunzip data/brain8.snd.gz
 test -f data/pollen2014.snd || gunzip data/pollen2014.snd.gz
 
 # Compile
-cd src/
-emmake make \
-    CC=emcc CXX=em++ \
-    CFLAGS="-O2 -s USE_ZLIB=1 -w" \
-    LIBS="-s USE_ZLIB=1 -lm"
-
-# Generate .wasm/.js files
-emcc -O2 -o ../build/t-sne.html t-sne-prgm.o \
+FLAGS=$(cat <<EOF
     $EM_FLAGS \
     -s ASYNCIFY=1 \
     -s 'ASYNCIFY_IMPORTS=["send_names","send_results"]' \
     -s EXPORTED_RUNTIME_METHODS=["callMain","getValue","UTF8ToString"] \
     --preload-file ../data/brain8.snd@/bhtsne/brain8.snd \
     --preload-file ../data/pollen2014.snd@/bhtsne/pollen2014.snd
+EOF
+)
+
+cd src/
+emmake make \
+    CC=emcc CXX=em++ \
+    CFLAGS="-O2 -s USE_ZLIB=1 -w" \
+    LIBS="-s USE_ZLIB=1 -lm $FLAGS"
 
 # Undo sample data unzipping
 cd -

--- a/tools/bhtsne/patches/1a62a5d
+++ b/tools/bhtsne/patches/1a62a5d
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index e9fc554..87a6e2c 100644
+index e9fc554..b4f06e6 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -5,7 +5,7 @@ CXXFLAGS=	$(CFLAGS)
@@ -7,7 +7,7 @@ index e9fc554..87a6e2c 100644
  ZLIB_FLAGS=	-DHAVE_ZLIB   # comment out this line to drop the zlib dependency
  INCLUDES=	-I.
 -PROG=		t-sne
-+PROG=		t-sne.html
++PROG=		../build/t-sne.html
  LIBS=		-lm -lz
  
  .SUFFIXES:.c .cpp .o

--- a/tools/bhtsne/patches/1a62a5d
+++ b/tools/bhtsne/patches/1a62a5d
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index e9fc554..7794556 100644
+index e9fc554..b8b735c 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -5,7 +5,7 @@ CXXFLAGS=	$(CFLAGS)
@@ -7,7 +7,7 @@ index e9fc554..7794556 100644
  ZLIB_FLAGS=	-DHAVE_ZLIB   # comment out this line to drop the zlib dependency
  INCLUDES=	-I.
 -PROG=		t-sne
-+PROG=		t-sne-prgm.o
++PROG=		t-sne-prgm.html
  LIBS=		-lm -lz
  
  .SUFFIXES:.c .cpp .o

--- a/tools/bhtsne/patches/1a62a5d
+++ b/tools/bhtsne/patches/1a62a5d
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index e9fc554..b8b735c 100644
+index e9fc554..87a6e2c 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -5,7 +5,7 @@ CXXFLAGS=	$(CFLAGS)
@@ -7,7 +7,7 @@ index e9fc554..b8b735c 100644
  ZLIB_FLAGS=	-DHAVE_ZLIB   # comment out this line to drop the zlib dependency
  INCLUDES=	-I.
 -PROG=		t-sne
-+PROG=		t-sne-prgm.html
++PROG=		t-sne.html
  LIBS=		-lm -lz
  
  .SUFFIXES:.c .cpp .o

--- a/tools/fastp/compile.sh
+++ b/tools/fastp/compile.sh
@@ -2,9 +2,6 @@
 
 cd src/
 curl -o "testdata/NA12878.fastq.gz" "https://sandbox.bio/data/NA12878.30k.fastq.gz"
-emmake make TARGET="fastp.o" LIBS="-s USE_ZLIB=1"
-em++ -O3 fastp.o \
-    -o ../build/fastp.html \
-    $EM_FLAGS \
-    --preload-file testdata@/fastp/testdata \
-    -s ASSERTIONS=1
+emmake make \
+    TARGET="../build/fastp.html" \
+    LIBS="-s USE_ZLIB=1 $EM_FLAGS --preload-file testdata@/fastp/testdata -s ASSERTIONS=1"

--- a/tools/samtools/compile.sh
+++ b/tools/samtools/compile.sh
@@ -14,6 +14,6 @@ autoconf -Wno-syntax
 emconfigure ./configure --without-curses --with-htslib="../../htslib/src/" CFLAGS="-s USE_ZLIB=1 -s USE_BZIP2=1"
 
 # Build
-emmake make CC=emcc AR=emar \
-    CFLAGS="-O2 -s USE_ZLIB=1 -s USE_BZIP2=1 $EM_FLAGS --preload-file examples/@/samtools/examples/" \
-    LDFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0"
+emmake make samtools CC=emcc AR=emar \
+    CFLAGS="-O2 -s USE_ZLIB=1 -s USE_BZIP2=1" \
+    LDFLAGS="$EM_FLAGS --preload-file examples/@/samtools/examples/ -s ERROR_ON_UNDEFINED_SYMBOLS=0 -O2"

--- a/tools/samtools/compile.sh
+++ b/tools/samtools/compile.sh
@@ -12,14 +12,8 @@ make clean
 autoheader
 autoconf -Wno-syntax
 emconfigure ./configure --without-curses --with-htslib="../../htslib/src/" CFLAGS="-s USE_ZLIB=1 -s USE_BZIP2=1"
-emmake make CC=emcc AR=emar \
-    CFLAGS="-O2 -s USE_ZLIB=1 -s USE_BZIP2=1" \
-    LDFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0"
 
-# Generate .wasm/.js files
-emcc -O2 samtools.o \
-    -o ../build/samtools.html \
-    $EM_FLAGS \
-    -s USE_BZIP2=1 \
-    -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
-    --preload-file examples/@/samtools/examples/
+# Build
+emmake make CC=emcc AR=emar \
+    CFLAGS="-O2 -s USE_ZLIB=1 -s USE_BZIP2=1 $EM_FLAGS --preload-file examples/@/samtools/examples/" \
+    LDFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0"

--- a/tools/samtools/patches/1.10
+++ b/tools/samtools/patches/1.10
@@ -1,25 +1,16 @@
 diff --git a/Makefile b/Makefile
-index 160314a..8c64e7a 100644
+index 160314a..80cfa5a 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -66,7 +66,7 @@ INSTALL_PROGRAM = $(INSTALL)
- INSTALL_SCRIPT  = $(INSTALL_PROGRAM)
- 
- 
--PROGRAMS = samtools
-+PROGRAMS = samtools.o
- 
- MISC_PROGRAMS = \
- 	misc/ace2sam misc/maq2sam-long misc/maq2sam-short \
-@@ -139,7 +139,7 @@ lib:libbam.a
- libbam.a:$(LOBJS)
+@@ -140,7 +140,7 @@ libbam.a:$(LOBJS)
  	$(AR) -csru $@ $(LOBJS)
  
--samtools: $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB)
-+samtools.o: $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB)
- 	$(CC) $(ALL_LDFLAGS) -o $@ $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB_LIB) $(CURSES_LIB) -lm $(ALL_LIBS) -lpthread
+ samtools: $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB)
+-	$(CC) $(ALL_LDFLAGS) -o $@ $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB_LIB) $(CURSES_LIB) -lm $(ALL_LIBS) -lpthread
++	$(CC) $(ALL_LDFLAGS) -o ../build/$@.html $(AOBJS) $(LZ4OBJS) libbam.a libst.a $(HTSLIB_LIB) $(CURSES_LIB) -lm $(ALL_LIBS) -lpthread
  
  # For building samtools and its test suite only: NOT to be installed.
+ libst.a: $(LIBST_OBJS)
 diff --git a/bam_sort.c b/bam_sort.c
 index 0bf346c..22aff33 100644
 --- a/bam_sort.c

--- a/tools/seq-align/compile.sh
+++ b/tools/seq-align/compile.sh
@@ -16,16 +16,3 @@ find . -name 'Makefile' -exec sed -i '/^CFLAGS/ s/$/ -s USE_ZLIB=1/g' {} \;
 
 # Build
 emmake make
-
-# Generate JS/Wasm for each tool
-em++ -O3 bin/needleman_wunsch.o \
-    -o ../build/needleman_wunsch.html \
-    $EM_FLAGS
-
-em++ -O3 bin/smith_waterman.o \
-    -o ../build/smith_waterman.html \
-    $EM_FLAGS
-
-em++ -O3 bin/lcs.o \
-    -o ../build/lcs.html \
-    $EM_FLAGS

--- a/tools/seq-align/patches/dc41988
+++ b/tools/seq-align/patches/dc41988
@@ -1,24 +1,21 @@
 diff --git a/Makefile b/Makefile
-index d6f002b..44aebc8 100644
+index d6f002b..9377a09 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -29,13 +29,16 @@ src/libalign.a: $(OBJS)
+@@ -29,13 +29,13 @@ src/libalign.a: $(OBJS)
  	$(CC) $(CFLAGS) $(OBJFLAGS) $(INCS) -c $< -o $@
  
  bin/needleman_wunsch: src/tools/nw_cmdline.c src/libalign.a | bin
 -	$(CC) -o bin/needleman_wunsch $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/nw_cmdline.c $(LINKFLAGS)
-+	$(CC) -O3 -o bin/needleman_wunsch.o $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/nw_cmdline.c $(LINKFLAGS) \
-+		-s EXTRA_EXPORTED_RUNTIME_METHODS='["callMain"]'
++	$(CC) -O3 -o bin/needleman_wunsch.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/nw_cmdline.c $(LINKFLAGS) $EM_FLAGS
  
  bin/smith_waterman: src/tools/sw_cmdline.c src/libalign.a | bin
 -	$(CC) -o bin/smith_waterman $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/sw_cmdline.c $(LINKFLAGS)
-+	$(CC) -O3 -o bin/smith_waterman.o $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/sw_cmdline.c $(LINKFLAGS) \
-+		-s EXTRA_EXPORTED_RUNTIME_METHODS='["callMain"]'
++	$(CC) -O3 -o bin/smith_waterman.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/sw_cmdline.c $(LINKFLAGS) $EM_FLAGS
  
  bin/lcs: src/tools/lcs_cmdline.c src/libalign.a | bin
 -	$(CC) -o bin/lcs $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/lcs_cmdline.c $(LINKFLAGS)
-+	$(CC) -O3 -o bin/lcs.o $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/lcs_cmdline.c $(LINKFLAGS) \
-+		-s EXTRA_EXPORTED_RUNTIME_METHODS='["callMain"]'
++	$(CC) -O3 -o bin/lcs.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/lcs_cmdline.c $(LINKFLAGS) $EM_FLAGS
  
  bin/seq_align_tests: src/tools/tests.c src/libalign.a
  	mkdir -p bin

--- a/tools/seq-align/patches/dc41988
+++ b/tools/seq-align/patches/dc41988
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index d6f002b..9377a09 100644
+index d6f002b..d841eeb 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -29,13 +29,13 @@ src/libalign.a: $(OBJS)
@@ -7,15 +7,15 @@ index d6f002b..9377a09 100644
  
  bin/needleman_wunsch: src/tools/nw_cmdline.c src/libalign.a | bin
 -	$(CC) -o bin/needleman_wunsch $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/nw_cmdline.c $(LINKFLAGS)
-+	$(CC) -O3 -o bin/needleman_wunsch.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/nw_cmdline.c $(LINKFLAGS) $EM_FLAGS
++	$(CC) -O3 -o bin/needleman_wunsch.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/nw_cmdline.c $(LINKFLAGS) $(EM_FLAGS)
  
  bin/smith_waterman: src/tools/sw_cmdline.c src/libalign.a | bin
 -	$(CC) -o bin/smith_waterman $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/sw_cmdline.c $(LINKFLAGS)
-+	$(CC) -O3 -o bin/smith_waterman.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/sw_cmdline.c $(LINKFLAGS) $EM_FLAGS
++	$(CC) -O3 -o bin/smith_waterman.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/sw_cmdline.c $(LINKFLAGS) $(EM_FLAGS)
  
  bin/lcs: src/tools/lcs_cmdline.c src/libalign.a | bin
 -	$(CC) -o bin/lcs $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/lcs_cmdline.c $(LINKFLAGS)
-+	$(CC) -O3 -o bin/lcs.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/lcs_cmdline.c $(LINKFLAGS) $EM_FLAGS
++	$(CC) -O3 -o bin/lcs.html $(SRCS) $(TGTFLAGS) $(INCS) $(LIBS) src/tools/lcs_cmdline.c $(LINKFLAGS) $(EM_FLAGS)
  
  bin/seq_align_tests: src/tools/tests.c src/libalign.a
  	mkdir -p bin

--- a/tools/ssw/README.md
+++ b/tools/ssw/README.md
@@ -2,10 +2,12 @@
 
 ### Warning
 
-This implementation of Smith-Waterman relies on SIMD instructions, which are not supported by default in browsers. To enable SIMD:
+This implementation of Smith-Waterman relies on SIMD instructions to run in a performant way. If the end user does not have SIMD enabled, Aioli will load the `ssw-nosimd.wasm` version, though it is considerably slower.
 
-* **Firefox**: Go to [about:config](about:config), search for `javascript.options.wasm_simd` and toggle to `true`.
-* **Chrome**: Go to [chrome://flags](chrome://flags), search for `WebAssembly SIMD support` and toggle to `Enabled`
+To enable SIMD in your browser:
+
+* **Firefox**: Go to [about:config](about:config), search for `javascript.options.wasm_simd` and toggle to `true` (enabled by default as of Firefox 89)
+* **Chrome**: Go to [chrome://flags](chrome://flags), search for `WebAssembly SIMD support` and toggle to `Enabled` (enabled by default as of Chrome 91)
 
 ### Usage
 


### PR DESCRIPTION
This PR adds support for Emscripten 2.0.25 (currently using at 2.0.0)

* Upgrade emsdk to v10 and Emscripten to 2.0.25
* Skip some GitHub Actions steps if we're running the job locally using `act`
* Renamed `EXTRA_EXPORTED_RUNTIME_METHODS` to `EXPORTED_RUNTIME_METHODS` since it is deprecated
* Update all tools so they compile to WebAssembly
