### PR TITLE
Improve stats CDN/cron

### DIFF
--- a/cloudflare/cdn/entrypoint/index.js
+++ b/cloudflare/cdn/entrypoint/index.js
@@ -49,11 +49,9 @@ async function handleEvent(event) {
     let response = await getAssetFromKV(event, {
       mapRequestToAsset: handlePrefix(),
       cacheControl: {
-        browserTTL: 604800  // 1 week
-        // Defaults:
-        //   browserTTL: null, // do not set cache control ttl on responses
-        //   edgeTTL: 2 * 60 * 60 * 24, // 2 days
-        //   bypassCache: false, // do not bypass Cloudflare's cache
+        browserTTL: 604800,  // 1 week (default: null)
+        edgeTTL: 172800,     // 2 days (default: 2 days)
+        bypassCache: false   // Do not bypass Cloudflare's cache (default: false)
       }
     });
 

--- a/cloudflare/cdn/entrypoint/index.js
+++ b/cloudflare/cdn/entrypoint/index.js
@@ -10,7 +10,7 @@
 // log basic stats about the number of downloads per module.
 
 import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
-
+import * as TOOLS from "../../../config/tools.json";
 const URL_PREFIX = "/v2";
 
 // Function called when we go to cdn.biowasm.com/v2/
@@ -29,12 +29,18 @@ addEventListener("fetch", event => {
   let url = new URL(event.request.url);
   if(url.host.startsWith("cdn") && url.host.endsWith(".biowasm.com") && url.pathname.endsWith(".js")) {
     async function logEvent(path) {
-      const uuid = await fetch("https://csprng.xyz/v1/api?length=10").then(d => d.json()).then(d => d.Data);
+      // Parse path. Format = /v2/<tool>/<version>/<program>.js
+      const tool = path.split("/")[2];  // [0] = "" because of the leading /
+      // Only log valid tools
+      if(tool != "aioli" && !(tool in TOOLS.tools))
+        return;
+
       // ISO Date Format: <YYYY-MM-DDTHH:mm:ss.sssZ> --> want YYYY-MM-DD
-      // Path format: /v2/<tool>/<version>/<program>.js
-      let key = `raw:${new Date().toISOString().split("T").shift()}:${path.split("/")[2]}:${uuid}`;
+      const date = new Date().toISOString().split("T").shift();
+      // Append a UUID to the key so we don't overwrite another one
+      const uuid = await fetch("https://csprng.xyz/v1/api?length=10").then(d => d.json()).then(d => d.Data);
       // Log event
-      await LOGS.put(key, "");
+      await LOGS.put(`raw:${date}:${tool}:${uuid}`, "");
     }
     event.waitUntil(logEvent(url.pathname));
   }

--- a/cloudflare/cdn/entrypoint/index.js
+++ b/cloudflare/cdn/entrypoint/index.js
@@ -29,12 +29,12 @@ addEventListener("fetch", event => {
   let url = new URL(event.request.url);
   if(url.host.startsWith("cdn") && url.host.endsWith(".biowasm.com") && url.pathname.endsWith(".js")) {
     async function logEvent(path) {
-      // ISO Date Format: <YYYY-MM-DDTHH:mm:ss.sssZ>
-      let key = `${new Date().toISOString().split("T").shift()}|${path}`;
-      // Increment count
-      let counter = parseInt((await LOGS.getWithMetadata(key)).metadata || 0) + 1;
-      // Save count in the metadata so we can retrieve it in bulk when doing .list() for CDN stats
-      await LOGS.put(key, "", { metadata: counter });
+      const uuid = await fetch("https://csprng.xyz/v1/api?length=10").then(d => d.json()).then(d => d.Data);
+      // ISO Date Format: <YYYY-MM-DDTHH:mm:ss.sssZ> --> want YYYY-MM-DD
+      // Path format: /v2/<tool>/<version>/<program>.js
+      let key = `raw:${new Date().toISOString().split("T").shift()}:${path.split("/")[2]}:${uuid}`;
+      // Log event
+      await LOGS.put(key, "");
     }
     event.waitUntil(logEvent(url.pathname));
   }

--- a/cloudflare/cdn/wrangler.toml
+++ b/cloudflare/cdn/wrangler.toml
@@ -11,7 +11,7 @@ name = "biowasm-v2-cdn-stg"
 vars = { ENVIRONMENT = "stg" }
 route = "cdn-stg.biowasm.com/v2/*"
 kv_namespaces = [
-    { binding = "LOGS", id = "e76f7352461c4b82997961622b33e878" }
+    { binding = "LOGS", id = "dd7c61572f59436796f1404eff1eec3a" }
 ]
 
 [env.prd]
@@ -19,5 +19,5 @@ name = "biowasm-v2-cdn"
 vars = { ENVIRONMENT = "prd" }
 route = "cdn.biowasm.com/v2/*"
 kv_namespaces = [
-    { binding = "LOGS", id = "d8adbc35772042248a89727658808f96" }
+    { binding = "LOGS", id = "51cfc57233574476be9cd5bb2252dc79" }
 ]

--- a/cloudflare/stats/index.js
+++ b/cloudflare/stats/index.js
@@ -12,15 +12,26 @@ const KEY_SUMMARY = "summary";
 // ================================================================
 async function handleRequest(request)
 {
-	let data = [];
+	// KV format: { <date>: { <tool>: <count> } }
 	let stats = JSON.parse(await LOGS.get(KEY_SUMMARY));
 
+	// Convert to format { <tool> : { <date>: <count> } }
+	let statsT = {};
+	for(let date in stats) {
+		for(let tool in stats[date]) {
+			const count = stats[date][tool];
+			if(!(tool in statsT))
+				statsT[tool] = {};
+			statsT[tool][date] = count;
+		}
+	}
+
 	// Convert to Plotly format
-	// KV format: { "date": "tool": count }
 	// Plotly format: [ { name: "tool", type: "scatter", x: [date1, date2, ...], y: [count1, count2, ...] } ]
-	for(let prgm in stats) {
-		let x = Object.keys(stats[prgm]).sort();
-		let y = x.map(d => stats[prgm][d]);
+	let data = [];
+	for(let prgm in statsT) {
+		let x = Object.keys(statsT[prgm]).sort();
+		let y = x.map(d => statsT[prgm][d]);
 		data.push({
 			name: prgm,
 			x: x, y: y,

--- a/cloudflare/stats/index.js
+++ b/cloudflare/stats/index.js
@@ -1,37 +1,34 @@
 // This file defines a Cloudflare Worker that:
 //   (1) When called as a cron job, tallies up how often each tool was downloaded
-//       from the CDN over time, and stores those counts as "SUMMARY_AGGREGATED".
+//       from the CDN over time, and stores those counts as "summary".
 //   (2) When called as a GET endpoint, uses the summary stats calculated by the
 //       cron above to plot a chart of download counts over time.
 
-// KV key names; summaries are calculated and split by versions,
-// or aggregateda cross all versions.
-const KEY_SUMMARY_SPLIT = "SUMMARY_SPLIT";
-const KEY_SUMMARY_AGGREGATED = "SUMMARY_AGGREGATED";
+// KV key name
+const KEY_SUMMARY = "summary";
 
 // ================================================================
 // Web endpoint
 // ================================================================
 async function handleRequest(request)
 {
-  let data = [];
-  let stats = JSON.parse(await LOGS.get(KEY_SUMMARY_AGGREGATED));
+	let data = [];
+	let stats = JSON.parse(await LOGS.get(KEY_SUMMARY));
 
-  // Convert to Plotly format
-  // Format: { "seqtk": { "2020-01-01": 4 } }
-  for(let prgm in stats)
-  {
-    let x = Object.keys(stats[prgm]).sort();
-    let y = x.map(d => stats[prgm][d]);
-    data.push({
-      x: x,
-      y: y,
-      name: prgm,
-      type: "scatter"
-    });
-  }
+	// Convert to Plotly format
+	// KV format: { "date": "tool": count }
+	// Plotly format: [ { name: "tool", type: "scatter", x: [date1, date2, ...], y: [count1, count2, ...] } ]
+	for(let prgm in stats) {
+		let x = Object.keys(stats[prgm]).sort();
+		let y = x.map(d => stats[prgm][d]);
+		data.push({
+			name: prgm,
+			x: x, y: y,
+			type: "scatter"
+		});
+	}
 
-  return new Response(`
+	return new Response(`
         <!doctype html>
         <html lang="en">
           <head>
@@ -98,9 +95,7 @@ async function handleRequest(request)
             </main>
           </body>
         </html>
-    `, {
-    headers: { "content-type": "text/html;charset=UTF-8" }
-  });
+    `, { headers: { "content-type": "text/html;charset=UTF-8" } });
 }
 
 // ================================================================
@@ -108,62 +103,113 @@ async function handleRequest(request)
 // ================================================================
 async function handleSchedule(scheduledDate)
 {
-  console.log(scheduledDate);
+	console.log(scheduledDate);
+	// ========================================================================
+	// First, look for raw, unaggregated log events, and aggregate them
+	// Raw events: raw:<date>:<tool>/<version>/<program>.wasm:<uuid> value="" metadata={}
+	// ========================================================================
+	let aggregated = {};  // { "2021-07-22": { "bowtie2": 123, ... }, ... }
+	let rawKeys = await getLogs({
+		prefix: "raw:",
+		fn: key => {
+			const value = key.name.split(":");         // key=raw:2021-07-22:samtools:uuid
+			const date = value[1];                     // 2021-07-22
+			const tool = value[2];                     // samtools
 
-  let statsSplit = {};       // {"/aioli/1.3.0/aioli.js": { "2020-01-01": 4 }}
-  let statsAggregated = {};  // {"aioli": { "2020-01-01": 4 }}
+			// Aggregate all versions
+			if(!(date in aggregated))
+				aggregated[date] = {};
+			if(!(tool in aggregated[date]))
+				aggregated[date][tool] = 0;
+			aggregated[date][tool]++;
 
-  // Loop through all key names using "cursor" for pagination.
-  // Note that the .list() API doesn't return values so we do
-  // that separately.
-  let response = { cursor: null };
-  do {
-    // Get next page of keys
-    response = await LOGS.list({
-      cursor: response.cursor
-    });
+			return key.name;
+		}
+	});
+	console.log(rawKeys)
+	console.log(aggregated)
 
-    // Parse the metadata (i.e. download counts) for every key
-    // Format:
-    // { keys: [{ name: "name", metadata: 123}], 
-    //   list_complete: false, cursor: "<CURSOR ID>"}] }
-    response.keys.map(d => {
-      const key = d.name.replace("/v2", "");
-      const count = d.metadata;
+	// Now that they're aggregated, we can update the key/value store counts
+	for(let date in aggregated) {
+		for(let tool in aggregated[date]) {
+			const key = `aggregate:${date}:${tool}`;
+			const count = parseInt((await LOGS.getWithMetadata(key)).metadata || 0);
+			const countToAdd = aggregated[date][tool];
+			await LOGS.put(key, "", { metadata: count + countToAdd });
+		}
+	}
 
-      // Parse key
-      [date, path] = key.split("|");
-      if(path == null)
-        return;
-      [_, prgm] = path.split("/");
+	// And we can delete the raw log events
+	for(let key of rawKeys) {
+		console.log(`Deleting ${key}...`)
+		await LOGS.delete(key);
+	}
 
-      // Split by version
-      if(!(path in statsSplit))
-        statsSplit[path] = {};
-      if(!(date in statsSplit[path]))
-        statsSplit[path][date] = 0;
-      statsSplit[path][date] += count;
-      // Aggregate all versions
-      if(!(prgm in statsAggregated))
-        statsAggregated[prgm] = {};
-      if(!(date in statsAggregated[prgm]))
-        statsAggregated[prgm][date] = 0;
-      statsAggregated[prgm][date] += count;
-    });
-  } while(response.cursor != null)
+	// ========================================================================
+	// Now fetch *all* aggregate KVs and save that to a summary KV
+	// Aggregate events: aggregate:<date>:<prgm>  value="" metadata=count
+	// Note that we store the summary JSON as { "tool": { "date" } } so it's 
+	// easier to plot as different series, but we store the key/value pairs as
+	// "date:tool" for sorting purposes.
+	// ========================================================================
+	aggregated = {};
+	await getLogs({
+		prefix: "aggregate:",
+		fn: key => {
+			const value = key.name.split(":");  // key=aggregate:2021-07-22:samtools metadata=count
+			const date = value[1];              // e.g. 2021-07-22
+			const prgm = value[2];              // e.g. samtools
+			const count = key.metadata;         // e.g. 123
 
-  await LOGS.put(KEY_SUMMARY_SPLIT, JSON.stringify(statsSplit));
-  await LOGS.put(KEY_SUMMARY_AGGREGATED, JSON.stringify(statsAggregated));
+			// Aggregate all versions
+			if(!(prgm in aggregated))
+				aggregated[prgm] = {};
+			if(!(date in aggregated[prgm]))
+				aggregated[prgm][date] = 0;
+			aggregated[prgm][date] += count;
+		}
+	});
+	console.log(aggregated);
+
+	// Save it so we can fetch it later quickly from the stats page
+	await LOGS.put(KEY_SUMMARY, JSON.stringify(aggregated));
 }
+
+
+// ================================================================
+// Utility functions
+// ================================================================
+
+async function getLogs(config)
+{
+	// Loop through all keys and handle pagination
+	let processed = [];
+	let response = { cursor: null };
+	do {
+		response = await LOGS.list({
+			prefix: config.prefix,
+			cursor: response.cursor
+		});
+
+		processed = processed.concat(response.keys.map(key => {
+			if(!config.fn)
+				return key
+			return config.fn(key);
+		}))
+	} while(response.cursor != null);
+
+	return processed;
+}
+
 
 // ================================================================
 // Event listeners
 // ================================================================
 
 addEventListener("fetch", event => {
-  return event.respondWith(handleRequest(event.request));
+	return event.respondWith(handleRequest(event.request));
 });
 
 addEventListener("scheduled", event => {
-  event.waitUntil(handleSchedule(event.scheduledTime));
+	event.waitUntil(handleSchedule(event.scheduledTime));
 });

--- a/cloudflare/stats/index.js
+++ b/cloudflare/stats/index.js
@@ -122,9 +122,9 @@ async function handleSchedule(scheduledDate)
 	}
 
 	// And we can delete the raw log events
-	for(let key of rawKeys) {
-		console.log(`Deleting ${key}...`)
-		await LOGS.delete(key);
+	for(let log of logsRaw) {
+		console.log(`Deleting ${log.name}...`)
+		await LOGS.delete(log.name);
 	}
 
 	// ========================================================================

--- a/cloudflare/stats/wrangler.toml
+++ b/cloudflare/stats/wrangler.toml
@@ -10,7 +10,7 @@ name = "biowasm-v2-stats-stg"
 vars = { ENVIRONMENT = "stg" }
 route = "stats-stg.biowasm.com/*"
 kv_namespaces = [
-    { binding = "LOGS", id = "e76f7352461c4b82997961622b33e878" }
+    { binding = "LOGS", id = "dd7c61572f59436796f1404eff1eec3a" }
 ]
 
 [env.prd]
@@ -18,5 +18,5 @@ name = "biowasm-v2-stats"
 vars = { ENVIRONMENT = "prd" }
 route = "stats.biowasm.com/*"
 kv_namespaces = [
-    { binding = "LOGS", id = "d8adbc35772042248a89727658808f96" }
+    { binding = "LOGS", id = "51cfc57233574476be9cd5bb2252dc79" }
 ]


### PR DESCRIPTION
This PR addresses the stats issues listed in #50 

- Refactor how we log downloads. Currently, we increment a count when a file is downloaded, which can produce incorrect counts if we do so simultaneously from different sources. Instead, when a file is downloaded, log it as a "raw" event, and use the cron that runs every 30mins to aggregate the raw events
- Update `wrangler.toml` so we use the new Cloudflare Worker key value stores for v2
- Make sure a tool is valid before logging it as viewed