### PR TITLE
Add CORS to local web server for contributing / testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,17 @@ apt-get install -y autoconf liblzma-dev less vim
 # Create small web server for testing
 cat << EOF > server.py
 import http.server
+from http.server import SimpleHTTPRequestHandler
 import socketserver
 
-handler = http.server.SimpleHTTPRequestHandler
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+       	SimpleHTTPRequestHandler.end_headers(self)
+
+handler = CORSRequestHandler
 handler.extensions_map['.wasm'] = 'application/wasm'
+
 httpd = socketserver.TCPServer(('', 80), handler)
 httpd.serve_forever()
 EOF


### PR DESCRIPTION
Hi Robert!

I was doing some testing with tn93 and I ran into this issue when trying to set up a local web server as per `CONTRIBUTING.md` so I could update some tn93 code, compile it, and fetch it using Aioli with the `urlPrefix` parameter. 

`Access to fetch at 'http://localhost:8080/build/tn93/test/tn93.js' from origin 'http://localhost:5173' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`

I've updated the python code that runs a simple testing web server to fix this CORS issue. I though I'd open a PR to mention this and see if it'd be of any help or to determine if I'm doing something wrong. Thanks!