### PR TITLE
Add cawlign to biowasm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -129,3 +129,6 @@
 [submodule "tools/wgsim/src"]
 	path = tools/wgsim/src
 	url = https://github.com/lh3/wgsim.git
+[submodule "tools/cawlign/src"]
+	path = tools/cawlign/src
+	url = https://github.com/veg/cawlign.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,10 @@
 	path = tools/bowtie2/src
 	url = https://github.com/BenLangmead/bowtie2
 
+[submodule "tools/cawlign/src"]
+	path = tools/cawlign/src
+	url = https://github.com/veg/cawlign.git
+
 [submodule "tools/coreutils/src"]
 	path = tools/coreutils/src
 	url = https://github.com/coreutils/coreutils.git
@@ -129,6 +133,3 @@
 [submodule "tools/wgsim/src"]
 	path = tools/wgsim/src
 	url = https://github.com/lh3/wgsim.git
-[submodule "tools/cawlign/src"]
-	path = tools/cawlign/src
-	url = https://github.com/veg/cawlign.git

--- a/biowasm.json
+++ b/biowasm.json
@@ -82,6 +82,18 @@
 				}
 			]
 		},
+        {
+            "name": "cawlign",
+            "programs": ["cawlign"],
+            "description": "Align/map sequences in a FASTA file to a reference sequence in a codon-aware manner",
+            "files": ["js", "wasm", "data"],
+            "versions": [
+                {
+                    "version": "0.1.0",
+                    "branch": "v0.1.0"
+                }
+            ]
+        },
 		{
 			"name": "coreutils",
 			"programs": ["basename", "cat", "comm", "cut", "date", "df", "dirname", "du", "echo", "env", "fold", "head", "join", "ls", "md5sum", "paste", "seq", "shuf", "sort", "tail", "tee", "tr", "uniq", "wc"],

--- a/tools/cawlign/compile.sh
+++ b/tools/cawlign/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Remove extra space in front of Emscripten "-s" variables to avoid errors
-emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file test@/cawlign" .
+emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file test@/cawlign --preload-file res@/cawlign" .
 emmake make cawlign
 mv cawlign.{js,wasm,data} ../build/

--- a/tools/cawlign/compile.sh
+++ b/tools/cawlign/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Remove extra space in front of Emscripten "-s" variables to avoid errors
-emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file test@/cawlign --preload-file res@/cawlign" .
+emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file res@/cawlign" .
 emmake make cawlign
 mv cawlign.{js,wasm,data} ../build/

--- a/tools/cawlign/compile.sh
+++ b/tools/cawlign/compile.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Remove extra space in front of Emscripten "-s" variables to avoid errors
+emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file data@/cawlign" .
+emmake make cawlign
+mv cawlign.{js,wasm,data} ../build/

--- a/tools/cawlign/compile.sh
+++ b/tools/cawlign/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Remove extra space in front of Emscripten "-s" variables to avoid errors
-emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file data@/cawlign" .
+emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="${EM_FLAGS//-s /-s} --preload-file test@/cawlign" .
 emmake make cawlign
 mv cawlign.{js,wasm,data} ../build/

--- a/tools/cawlign/examples/v0.1.0.html
+++ b/tools/cawlign/examples/v0.1.0.html
@@ -1,0 +1,18 @@
+<script src="https://biowasm.com/cdn/v3/aioli.js"></script>
+<script type="module">
+const CLI = await new Aioli(["cawlign/0.1.0"]);
+
+// Align a sequence in test.fas against a reference genome
+// const output = await CLI.exec("tn93 -t 0.05 -o test.dst /shared/tn93/test.fas"); // TODO
+// const result = await CLI.cat("test.dst"); // TODO
+
+// Output results
+document.getElementById("output").innerHTML = output;
+document.getElementById("result").innerHTML = result;
+</script>
+
+<h4>Output of <code>cawlign</code>:</h4>
+<pre id="output">Loading...</pre>
+
+<h4>Pairwise distances:</h4>
+<pre id="result">Loading...</pre>

--- a/tools/cawlign/examples/v0.1.0.html
+++ b/tools/cawlign/examples/v0.1.0.html
@@ -2,8 +2,13 @@
 <script type="module">
 const CLI = await new Aioli(["cawlign/0.1.0"]);
 
+// Mount a ref genome from GitHub (this works because raw GitHub files are CORS-enabled)
+const mounts = await CLI.mount([
+    { name: "HIV1-pol-326.fa", url: "https://raw.githubusercontent.com/veg/cawlign/v0.1.0/test/HIV1-pol-326.fa" },
+]);
+
 // Align a sequence in test.fas against a reference genome
-const output = await CLI.exec("cawlign -o test.aln -r /shared/cawlign/references/HXB2_pol /shared/cawlign/HIV1-pol-326.fa");
+const output = await CLI.exec(`cawlign -o test.aln -r /shared/cawlign/references/HXB2_pol ${mounts[0]}`);
 const result = await CLI.cat("test.aln");
 
 // Output results

--- a/tools/cawlign/examples/v0.1.0.html
+++ b/tools/cawlign/examples/v0.1.0.html
@@ -3,8 +3,8 @@
 const CLI = await new Aioli(["cawlign/0.1.0"]);
 
 // Align a sequence in test.fas against a reference genome
-// const output = await CLI.exec("tn93 -t 0.05 -o test.dst /shared/tn93/test.fas"); // TODO
-// const result = await CLI.cat("test.dst"); // TODO
+const output = await CLI.exec("cawlign -o test.aln /shared/cawlign/HIV1-pol-326.fa");
+const result = await CLI.cat("test.aln");
 
 // Output results
 document.getElementById("output").innerHTML = output;

--- a/tools/cawlign/examples/v0.1.0.html
+++ b/tools/cawlign/examples/v0.1.0.html
@@ -3,7 +3,7 @@
 const CLI = await new Aioli(["cawlign/0.1.0"]);
 
 // Align a sequence in test.fas against a reference genome
-const output = await CLI.exec("cawlign -o test.aln -r /shared/cawlign/res/references/HXB2_pol /shared/cawlign/HIV1-pol-326.fa");
+const output = await CLI.exec("cawlign -o test.aln -r /shared/cawlign/references/HXB2_pol /shared/cawlign/HIV1-pol-326.fa");
 const result = await CLI.cat("test.aln");
 
 // Output results

--- a/tools/cawlign/examples/v0.1.0.html
+++ b/tools/cawlign/examples/v0.1.0.html
@@ -3,7 +3,7 @@
 const CLI = await new Aioli(["cawlign/0.1.0"]);
 
 // Align a sequence in test.fas against a reference genome
-const output = await CLI.exec("cawlign -o test.aln /shared/cawlign/HIV1-pol-326.fa");
+const output = await CLI.exec("cawlign -o test.aln -r /shared/cawlign/res/references/HXB2_pol /shared/cawlign/HIV1-pol-326.fa");
 const result = await CLI.cat("test.aln");
 
 // Output results


### PR DESCRIPTION
Hey, @robertaboukhalil! I was hoping to add [cawlign](https://github.com/veg/cawlign) to biowasm. I think its compilation and execution should be fairly similar to [tn93](https://github.com/veg/tn93), so I'm hoping my updates that add it work correctly!