### PR TITLE
Update to cawlign example HTML

### DIFF
--- a/tools/cawlign/examples/v0.1.0.html
+++ b/tools/cawlign/examples/v0.1.0.html
@@ -19,5 +19,5 @@ document.getElementById("result").innerHTML = result;
 <h4>Output of <code>cawlign</code>:</h4>
 <pre id="output">Loading...</pre>
 
-<h4>Pairwise distances:</h4>
+<h4>Alignments:</h4>
 <pre id="result">Loading...</pre>


### PR DESCRIPTION
I originally created the `cawlign` example HTML using the `tn93` example HTML as a starting point, and I forgot to replace the "Pairwise distances:" header to "Alignments:" (`tn93` outputs pairwise distances, whereas `cawlign` outputs alignments to a reference genome)