### PR TITLE
Add ncbi-blast

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -110,6 +110,10 @@
 	path = tools/muscle/src
 	url = https://github.com/rcedgar/muscle.git
 
+[submodule "tools/ncbi-blast/src"]
+	path = tools/ncbi-blast/src
+	url = https://github.com/ncbi/ncbi-cxx-toolkit-public.git
+
 [submodule "tools/samtools/src"]
 	path = tools/samtools/src
 	url = https://github.com/samtools/samtools.git

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:2.0.25 as wasm-builder
+FROM emscripten/emsdk:6.0.9 as wasm-builder
 
 RUN apt-get update && apt-get install -y autoconf liblzma-dev
 

--- a/biowasm.json
+++ b/biowasm.json
@@ -387,6 +387,17 @@
 			]
 		},
 		{
+			"name": "ncbi-blast",
+			"programs": ["blast_formatter", "blast_usage_report", "blastdb_aliastool", "blastdb_convert", "blastdb_path", "blastdbcheck", "blastdbcmd", "blastdbcp", "blastn", "blastp", "blastx", "clusterdbcmd", "convert2blastmask", "deltablast", "dustmasker", "makeblastdb", "makeclusterdb", "makeprofiledb", "psiblast", "rpsblast", "rpstblastn", "seedtop", "segmasker", "tblastn", "tblastx", "windowmasker"],
+			"description": "Basic local alignment search tool",
+			"versions": [
+				{
+					"version": "1.17.0-bd069ee",
+					"branch": "1.17.0-bd069ee"
+				}
+			]
+		},
+		{
 			"name": "samtools",
 			"programs": ["samtools"],
 			"description": "Parse .sam / .bam read alignment files",

--- a/tools/ncbi-blast/compile.sh
+++ b/tools/ncbi-blast/compile.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+shopt -s globstar nullglob
+
+BUILD_FLAGS="-fwasm-exceptions -s USE_SQLITE3=1 -O3"
+
+# configure and build native datatool binaries
+./configure --with-projects=scripts/projects/datatool/project.lst --with-build-root=native
+make -C native/build all_p
+
+# configure wasm build
+emconfigure ./configure AR="emar cr" \
+  --with-static \
+  --without-debug \
+  --without-mt \
+  --without-openmp \
+  --without-dll \
+  --without-vdb \
+  --without-ngs \
+  --without-gnutls \
+  --without-gcrypt \
+  --without-ncbicrypt \
+  --without-curl \
+  --without-mysql \
+  --without-bdb \
+  --without-sybase \
+  --without-ftds \
+  --without-gui \
+  --without-opengl \
+  --without-z \
+  --without-bz2 \
+  --without-lzo \
+  --without-zstd \
+  --without-pcre \
+  --without-pcre2 \
+  --without-expat \
+  --without-libxml \
+  --without-libxslt \
+  --without-lmdb \
+  --without-boost \
+  --without-sablot \
+  --without-xerces \
+  --without-xalan \
+  --without-strip \
+  --host=wasm32-unknown-none \
+  --with-projects=scripts/projects/blast/project.lst \
+  --with-build-root=wasm
+
+NCBI_DATATOOL_PATH="$(realpath native/bin)" make -C wasm/build CFLAGS="$BUILD_FLAGS" CXXFLAGS="$BUILD_FLAGS" LDFLAGS="$EM_FLAGS $BUILD_FLAGS -sERROR_ON_UNDEFINED_SYMBOLS=0 -sSTACK_SIZE=1048576" all_p
+
+for f in wasm/build/app/**/*.wasm; do
+    mv ${f%.wasm} ../build/$(basename $f .wasm).js
+    mv $f ../build/
+done

--- a/tools/ncbi-blast/patches/1.17.0-bd069ee.patch
+++ b/tools/ncbi-blast/patches/1.17.0-bd069ee.patch
@@ -1,0 +1,106 @@
+--- a/scripts/projects/blast/project.lst
++++ b/scripts/projects/blast/project.lst
+@@ -100,6 +100,7 @@ app/dustmasker$
+ app/segmasker$
+ app/blastvdb
+ objtools/simple$
++-objects/genomecoll/gc_cli
+ -objects/.*/test
+ -objects/.*/demo
+ -objects/.*/unit_test
+--- a/src/algo/blast/format/vecscreen_run.cpp
++++ b/src/algo/blast/format/vecscreen_run.cpp
+@@ -476,7 +476,7 @@ CVecscreenRun::CFormatter::FormatResults(CNcbiOstream& out,
+                     jobj.insert("query_end", align.GetSeqStop(0)+1);
+                     jobj.insert("query_strand", (align.GetSeqStrand(0)==eNa_strand_plus?"+":"-"));
+                     jobj.insert("match_strength", match_type_strs[match_score]);
+-                    jobj.insert("drop_count", mi->drops.size());
++                    jobj.insert("drop_count", static_cast<Uint8>(mi->drops.size()));
+                     jobj.insert("subject_id", sid);
+                     jobj.insert("subject_title", stitle);
+                 
+--- a/src/build-system/Makefile.mk.in
++++ b/src/build-system/Makefile.mk.in
+@@ -385,7 +385,7 @@ ZSTD_LIB    =
+ CMPRS_INCLUDE = $(Z_INCLUDE) $(BZ2_INCLUDE) $(LZO_INCLUDE) $(ZSTD_INCLUDE)
+ CMPRS_LIBS    = $(Z_LIBS) $(BZ2_LIBS) $(LZO_LIBS) $(ZSTD_LIBS)
+ CMPRS_STATIC_LIBS = $(Z_LIBS) $(BZ2_LIBS) $(LZO_LIBS) $(ZSTD_STATIC_LIBS)
+-CMPRS_LIB     = $(Z_LIB) $(BZ2_LIB) $(ZSTD_LIB) zcf
++CMPRS_LIB     = $(Z_LIB) $(BZ2_LIB) $(ZSTD_LIB)
+ 
+ # Perl-Compatible Regular Expressions
+ # For historical reasons, the bundled (LIB) version contains the POSIX
+--- a/src/build-system/configure
++++ b/src/build-system/configure
+@@ -18159,9 +18159,12 @@ $as_echo "$as_me: using local zlib copy in $zlocal" >&6;}
+    # AC_DEFINE(USE_LOCAL_ZLIB, 1, [Define to 1 if using a local copy of zlib.])
+              WithPackages="$WithPackages${WithPackagesSep}Z"; WithPackagesSep=" "
+              WithPackages="$WithPackages${WithPackagesSep}LocalZ"; WithPackagesSep=" "
++
++$as_echo "#define HAVE_LIBZ 1" >>confdefs.h
++
+ fi
+ # Cloudflare fork, always present in practice
+-if test -d "$real_srcdir/include/util/compress/zlib_cloudflare"; then
++if test -d "$real_srcdir/include/util/compress/zlib_cloudflare"  &&  test "$host_os" != none; then
+ 
+ $as_echo "#define HAVE_LIBZCF 1" >>confdefs.h
+ 
+--- a/src/build-system/configure.ac
++++ b/src/build-system/configure.ac
+@@ -4849,9 +4849,11 @@ if test -z "$Z_LIBS"; then
+    # AC_DEFINE(USE_LOCAL_ZLIB, 1, [Define to 1 if using a local copy of zlib.])
+    NCBI_PACKAGE(Z)
+    NCBI_PACKAGE(LocalZ)
++   AC_DEFINE(HAVE_LIBZ, 1,
++      [Define to 1 if zlib is available.])
+ fi
+ # Cloudflare fork, always present in practice
+-if test -d "$real_srcdir/include/util/compress/zlib_cloudflare"; then
++if test -d "$real_srcdir/include/util/compress/zlib_cloudflare"  &&  test "$host_os" != none; then
+    AC_DEFINE(HAVE_LIBZCF, 1,
+       [Define to 1 if Cloudflare zlib is available (embedded).])
+ fi
+--- a/src/connect/ncbi_lbdns.c
++++ b/src/connect/ncbi_lbdns.c
+@@ -1269,7 +1269,7 @@ static int/*bool*/ s_Resolve(SERV_ITER iter)
+     const struct SLBDNS_Data* data = (const struct SLBDNS_Data*) iter->data;
+     struct sockaddr_in ns_save;
+     int ns_count, ns_retry, rv;
+-    u_long ns_options;
++    unsigned long ns_options;
+     res_state r;
+ 
+     assert(!data->n_cand  &&  !data->empty);
+--- a/src/util/compress/Makefile.in
++++ b/src/util/compress/Makefile.in
+@@ -1,6 +1,6 @@
+ # $Id$
+ 
+-SUB_PROJ = bzip2 zlib zlib_cloudflare api
++SUB_PROJ = bzip2 zlib api
+ PROJ_TAG = core
+ 
+ srcdir = @srcdir@
+--- a/src/util/compress/api/Makefile.compress.lib
++++ b/src/util/compress/api/Makefile.compress.lib
+@@ -7,7 +7,7 @@ LIB = xcompress
+ 
+ CPPFLAGS = $(ORIG_CPPFLAGS) $(CMPRS_INCLUDE)
+ 
+-DLL_LIB =  $(BZ2_LIB)  $(LZO_LIB)  $(Z_LIB)  $(ZSTD_LIB) zcf
++DLL_LIB =  $(BZ2_LIB)  $(LZO_LIB)  $(Z_LIB)  $(ZSTD_LIB)
+ LIBS    =  $(BZ2_LIBS) $(LZO_LIBS) $(Z_LIBS) $(ZSTD_LIBS) $(ORIG_LIBS)
+ 
+ WATCHERS = ivanov
+--- a/src/util/regexp/config.h
++++ b/src/util/regexp/config.h
+@@ -246,7 +246,7 @@ sure both macros are undefined; an emulation function will then be used. */
+ /* #undef SUPPORT_DIFF_FUZZ */
+ 
+ /* Define to any value to enable support for Just-In-Time compiling. */
+-#define SUPPORT_JIT 1
++/* #undef SUPPORT_JIT */
+ 
+ /* Define to any value to allow pcre2grep to be linked with libbz2, so that it
+    is able to handle .bz2 files. */


### PR DESCRIPTION
Hi, @robertaboukhalil !

I'm trying to compile ncbi-blast into webassembly, and have successfully made a working build locally.

I would like to contribute the build script to biowasm, while I met with some problems when adapting it to biowasm build pipeline. This draft PR gives a proof of concept for the building process, some details may require your decision or assistance:

1. [NCBI-BLAST+](https://blast.ncbi.nlm.nih.gov/doc/blast-help/downloadblastdata.html) is part of the [ncbi-cxx-toolkit](https://github.com/ncbi/ncbi-cxx-toolkit-public.git) repo and doesn't seem to have a separate repository. There is a version mismatch between ncbi-blast+ and ncbi-cxx-toolkit tag release. **need to decide what version number to use**.
2. Some of the blast program requires sqlite3. **need to upgrade emsdk** for sqlite3 (`-s USE_SQLITE3`) support.

Also, here are some experience to share:

1. `make` runs recursively into different directories, making it a bit difficult to provide `--preload-file` flags in `LD_FLAGS` elegantly
2. `-fwasm-exceptions` is required for C++ exception handling, otherwise internal errors (e.g. `blastn -help`) will crush the wasm program.
3. blast programs use some system calls which are not supported in wasm (e.g. `shmctl`), `-sERROR_ON_UNDEFINED_SYMBOLS=0` is required to ignore these missing symbols when linking.
4. For the same reason, several blastdb features are not available. For example, `makeblastdb` can only make v4 (`-blastdb_version 4`) but not default v5 database.

Please feel free to modify the PR to make it more in line with the conventions of biowasm. 